### PR TITLE
Fix remote image pattern

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,6 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'serwer1542079.home.pl',
-        port: '', // Default port (usually 443 for https)
         pathname: '/autoinstalator/wordpress/wp-content/uploads/**', // Allow any image in uploads directory
       },
     ],


### PR DESCRIPTION
## Summary
- fix remotePatterns config by removing invalid port value

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68409e07518c8326999e7a7ff02d0d1c